### PR TITLE
Introduce Sushi test in Japanese

### DIFF
--- a/src/main/java/org/springframework/polyglot/ja/test/context/すしコンフィグ.java
+++ b/src/main/java/org/springframework/polyglot/ja/test/context/すしコンフィグ.java
@@ -1,0 +1,41 @@
+package org.springframework.polyglot.ja.test.context;
+
+import org.springframework.core.annotation.AliasFor;
+import org.springframework.test.context.ContextConfiguration;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * 寿司好きのための{@link ContextConfiguration @ContextConfiguration}.
+ *
+ * @author Tadaya Tsuyukubo
+ * @since 1.0
+ */
+@ContextConfiguration
+@Documented
+@Inherited
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface すしコンフィグ {
+
+	@AliasFor(annotation = ContextConfiguration.class, attribute = "classes")
+	Class<?>[] 新鮮なネタ() default {};
+
+	@AliasFor(annotation = ContextConfiguration.class, attribute = "locations")
+	String[] 古いネタ() default {};
+
+	@AliasFor(annotation = ContextConfiguration.class, attribute = "inheritInitializers")
+	boolean さび抜き() default true;
+
+	@AliasFor(annotation = ContextConfiguration.class, attribute = "inheritLocations")
+	boolean おまかせ() default true;
+
+	@AliasFor(annotation = ContextConfiguration.class, attribute = "name")
+	String 今日のオススメ() default "";
+
+}

--- a/src/test/java/org/springframework/polyglot/ja/SushiTests.java
+++ b/src/test/java/org/springframework/polyglot/ja/SushiTests.java
@@ -1,0 +1,82 @@
+package org.springframework.polyglot.ja;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.polyglot.ja.test.context.すしコンフィグ;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.springframework.polyglot.ja.SushiTests.SushiConfig;
+
+/**
+ * Do you like Sushi?
+ *
+ * @author Tadaya Tsuyukubo
+ * @since 1.0
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@すしコンフィグ(新鮮なネタ = SushiConfig.class, さび抜き = false, おまかせ = true, 今日のオススメ = "まぐろがうまいよ！")
+public class SushiTests {
+
+	@Autowired
+	List<Sushi> 今日のネタ;
+
+	@Autowired
+	Sushi maguro;
+
+	@Test
+	public void 回る寿司() {
+		assertTrue(maguro.price < 400);
+	}
+
+	@Test
+	public void おあいそ() {
+		long total = 0;
+		for (Sushi sushi : 今日のネタ) {
+			total += sushi.price;
+		}
+		assertEquals("合計", 800, total);
+	}
+
+	@Configuration
+	static class SushiConfig {
+
+		@Bean
+		Sushi maguro() {
+			return new Sushi("まぐろ", 300);
+		}
+
+		@Bean
+		Sushi hamachi() {
+			return new Sushi("はまち", 200);
+		}
+
+		@Bean
+		Sushi salmon() {
+			return new Sushi("サーモン", 200);
+		}
+
+		@Bean
+		Sushi tamago() {
+			return new Sushi("玉子", 100);
+		}
+
+	}
+
+	static class Sushi {
+		String name;
+		int price;
+
+		public Sushi(String name, int price) {
+			this.name = name;
+			this.price = price;
+		}
+	}
+
+}


### PR DESCRIPTION
Japanese composed annotation for Sushi :sushi:

The composed ContextConfiguration in English is:

``` java
public @interface すしコンフィグ {  // Sushi Config

    @AliasFor(annotation = ContextConfiguration.class, attribute = "classes")
    Class<?>[] 新鮮なネタ() default {};   // Fresh fishes

    @AliasFor(annotation = ContextConfiguration.class, attribute = "locations")
    String[] 古いネタ() default {};  // Old fishes

    @AliasFor(annotation = ContextConfiguration.class, attribute = "inheritInitializers")
    boolean さび抜き() default true;    // no wasabi

    @AliasFor(annotation = ContextConfiguration.class, attribute = "inheritLocations")
    boolean おまかせ() default true;   // chef's choice

    @AliasFor(annotation = ContextConfiguration.class, attribute = "name")
    String 今日のオススメ() default "";   // today's recommendation

}
```
