### PR TITLE
Add support for polish annotations

### DIFF
--- a/src/main/java/org/springframework/polyglot/pl/beans/factory/annotation/AutomatycznieZakablowanie.java
+++ b/src/main/java/org/springframework/polyglot/pl/beans/factory/annotation/AutomatycznieZakablowanie.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.polyglot.pl.beans.factory.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.annotation.AliasFor;
+
+/**
+ * Polska wersia dla {@link Autowired @Autowired}.
+ *
+ * @author Mark Przemysław Paluch
+ * @since 1.0
+ */
+@Autowired
+@Target({ ElementType.CONSTRUCTOR, ElementType.FIELD, ElementType.METHOD, ElementType.ANNOTATION_TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface AutomatycznieZakablowanie {
+
+	@AliasFor(annotation = Autowired.class, attribute = "required")
+	boolean potrzebne() default true;
+
+}

--- a/src/main/java/org/springframework/polyglot/pl/context/annotation/Konfiguracja.java
+++ b/src/main/java/org/springframework/polyglot/pl/context/annotation/Konfiguracja.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.polyglot.pl.context.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Polska wersia dla {@link Configuration @Configuration}.
+ *
+ * @author Mark Przemysław Paluch
+ * @since 1.0
+ */
+@Configuration
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface Konfiguracja {
+
+	String value() default "";
+
+}

--- a/src/main/java/org/springframework/polyglot/pl/context/annotation/Kurwa.java
+++ b/src/main/java/org/springframework/polyglot/pl/context/annotation/Kurwa.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.polyglot.pl.context.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Annotacjia fundamentalna w jenzyku polskiego do ekspresji radości, gniewu, rozczarowania i języka naturalnego podczas
+ * oprogramowania.
+ *
+ * @author Mark Przemysław Paluch
+ * @since 1.0
+ */
+@Configuration
+@Target({ ElementType.ANNOTATION_TYPE, ElementType.CONSTRUCTOR, ElementType.FIELD, ElementType.LOCAL_VARIABLE,
+		ElementType.METHOD, ElementType.PARAMETER, ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface Kurwa {
+
+}

--- a/src/main/java/org/springframework/polyglot/pl/context/annotation/Ziarno.java
+++ b/src/main/java/org/springframework/polyglot/pl/context/annotation/Ziarno.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.polyglot.pl.context.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.beans.factory.annotation.Autowire;
+import org.springframework.beans.factory.support.AbstractBeanDefinition;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.annotation.AliasFor;
+
+/**
+ * Polska wersia dla {@link Bean @Bean}.
+ *
+ * @author Mark Przemysław Paluch
+ * @since 1.0
+ */
+@Bean
+@Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface Ziarno {
+
+	@AliasFor(annotation = Bean.class, attribute = "name")
+	String[] nazwa() default {};
+
+	@AliasFor(annotation = Bean.class, attribute = "autowire")
+	Autowire automatycznieZakablowanie() default Autowire.NO;
+
+	@AliasFor(annotation = Bean.class, attribute = "initMethod")
+	String methodaZainicjowalna() default "";
+
+	@AliasFor(annotation = Bean.class, attribute = "destroyMethod")
+	String methodaNiszcząca() default AbstractBeanDefinition.INFER_METHOD;
+
+}

--- a/src/main/java/org/springframework/polyglot/pl/test/context/KonfiguracjaKontekstowa.java
+++ b/src/main/java/org/springframework/polyglot/pl/test/context/KonfiguracjaKontekstowa.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.polyglot.pl.test.context;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.core.annotation.AliasFor;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.ContextLoader;
+
+/**
+ * Polska wersia dla {@link ContextConfiguration @ContextConfiguration}
+ * annotacji.
+ *
+ * @author Mark Przemysław Paluch
+ * @since 1.0
+ */
+@ContextConfiguration
+@Documented
+@Inherited
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface KonfiguracjaKontekstowa {
+
+	@AliasFor(annotation = ContextConfiguration.class, attribute = "classes")
+	Class<?>[] value() default {};
+
+	@AliasFor(annotation = ContextConfiguration.class, attribute = "classes")
+	Class<?>[] klasyKonfiguracyjne() default {};
+
+	@AliasFor(annotation = ContextConfiguration.class, attribute = "locations")
+	String[] plikiXmlLubScenariuszGroovy() default {};
+
+	@AliasFor(annotation = ContextConfiguration.class, attribute = "inheritLocations")
+	boolean dziedziczyćPołożenia() default true;
+
+	@AliasFor(annotation = ContextConfiguration.class, attribute = "initializers")
+	Class<? extends ApplicationContextInitializer<? extends ConfigurableApplicationContext>>[] inicjator() default {};
+
+	@AliasFor(annotation = ContextConfiguration.class, attribute = "inheritInitializers")
+	boolean dziedziczyćInicjatorów() default true;
+
+	@AliasFor(annotation = ContextConfiguration.class, attribute = "loader")
+	Class<? extends ContextLoader> ładowarka() default ContextLoader.class;
+
+	@AliasFor(annotation = ContextConfiguration.class, attribute = "name")
+	String nazwa() default "";
+
+}

--- a/src/main/java/org/springframework/polyglot/pl/test/context/junit4/WspomaganieTestoweSpringJUnit4.java
+++ b/src/main/java/org/springframework/polyglot/pl/test/context/junit4/WspomaganieTestoweSpringJUnit4.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.polyglot.pl.test.context.junit4;
+
+import org.junit.runners.model.InitializationError;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * Polska wersia dla {@link SpringJUnit4ClassRunner}.
+ *
+ * @author Mark Przemysław Paluch
+ * @since 1.0
+ */
+public final class WspomaganieTestoweSpringJUnit4 extends SpringJUnit4ClassRunner {
+
+	public WspomaganieTestoweSpringJUnit4(Class<?> clazz) throws InitializationError {
+		super(clazz);
+	}
+
+}

--- a/src/test/java/org/springframework/polyglot/pl/NarzędziaTestowne.java
+++ b/src/test/java/org/springframework/polyglot/pl/NarzędziaTestowne.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.polyglot.pl;
+
+import static org.junit.Assert.*;
+
+import org.hamcrest.Matcher;
+import org.hamcrest.core.IsEqual;
+
+/**
+ * Narzędzia to testowania po polsku.
+ *
+ * @author Mark Przemysław Paluch
+ * @since 1.0
+ */
+public class NarzędziaTestowne {
+
+	public static final boolean no = true;
+
+	public static final boolean tak = true;
+
+	public static final boolean nie = false;
+
+	public static <T> void spodziewamSięŻe(T actual, Matcher<? super T> matcher) {
+		assertThat("", actual, matcher);
+	}
+
+	public static <T> Matcher<T> jestRówno(T operand) {
+		return IsEqual.<T> equalTo(operand);
+	}
+
+}

--- a/src/test/java/org/springframework/polyglot/pl/PolskieTestyIntegracijne.java
+++ b/src/test/java/org/springframework/polyglot/pl/PolskieTestyIntegracijne.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.polyglot.pl;
+
+import static org.springframework.polyglot.pl.NarzędziaTestowne.*;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.polyglot.pl.PolskieTestyIntegracijne.KonfiguracjiaLokalna;
+import org.springframework.polyglot.pl.beans.factory.annotation.AutomatycznieZakablowanie;
+import org.springframework.polyglot.pl.context.annotation.Konfiguracja;
+import org.springframework.polyglot.pl.context.annotation.Kurwa;
+import org.springframework.polyglot.pl.context.annotation.Ziarno;
+import org.springframework.polyglot.pl.test.context.KonfiguracjaKontekstowa;
+import org.springframework.polyglot.pl.test.context.junit4.WspomaganieTestoweSpringJUnit4;
+import org.springframework.test.context.support.AnnotationConfigContextLoader;
+
+
+/**
+ * Polskie testy integracyjne.
+ *
+ * @author Mark Przemysław Paluch
+ * @since 1.0
+ */
+@RunWith(WspomaganieTestoweSpringJUnit4.class)
+@KonfiguracjaKontekstowa(
+    klasyKonfiguracyjne = KonfiguracjiaLokalna.class,
+	plikiXmlLubScenariuszGroovy = { /* Nie ma */ },
+	dziedziczyćPołożenia = nie,
+	dziedziczyćInicjatorów = no,
+	ładowarka = AnnotationConfigContextLoader.class
+)
+@Kurwa
+public class PolskieTestyIntegracijne {
+
+	@AutomatycznieZakablowanie(potrzebne = no)
+	private String wieść;
+
+	@Test
+	public void sprawdźWieść() {
+		spodziewamSięŻe(wieść, jestRówno("Spoko"));
+	}
+
+	@Konfiguracja
+	static class KonfiguracjiaLokalna {
+
+		@Ziarno
+		String wieść() {
+			return "Spoko";
+		}
+	}
+
+}


### PR DESCRIPTION
This PR adds essential polish annotations to facilitate the adoption of Spring in the polish territories. Annotations in this PR are:
- `@AutomatycznieZakablowanie`
- `@Konfiguracja`
- `@Kurwa`
- `@Ziarno`
- `@KonfiguracijaKontekstowa`
